### PR TITLE
Address Christine's Peer review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved `DriftReport` to include missingness-related changes.
 - Updated documentation for `compare_contracts` with explicit drift definitions and directionality.
 - Renamed the package in documentation/metadata to `pyos_data_validation`.
+- Removed shell prompt and split commands inside README command snippets for easier copy/paste.
+- Standardized docstrings across public APIs (consistent Notes formatting, Raises sections).
+- Added hyperlinks to Pandera, Great Expectations, and Pydantic in README comparison section.
+- Added docs to the developer guid install list for quartodoc build to work.
 
 ### Tests
 - Added comprehensive unit tests for `compare_contracts`, covering schema drift, constraint drift, edge cases, and error handling.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 ---
 
 ## Table of Contents
-- [Quick Start](#get-started)
 - [Function Reference](#function-reference)
+- [Quick Start](#get-started)
 - [Usage Examples](#usage-examples)
 - [Developer Guide](#developer-guide)
 - [Contributors](#contributors)
@@ -501,7 +501,7 @@ for kind, count in summary.counts_by_kind.items():
 
 `pyos_data_validation` is inspired by production-grade data validation frameworks but serves a different purpose:
 
-| Feature | pyos_data_validation | Pandera | Great Expectations | Pydantic |
+| Feature | pyos_data_validation | [Pandera](https://pandera.readthedocs.io/) | [Great Expectations](https://greatexpectations.io/) | [Pydantic](https://docs.pydantic.dev/) |
 |---------|---------------------|---------|-------------------|----------|
 | **Target Use Case** | Educational, lightweight validation | Production data validation | Enterprise data quality | API input validation |
 | **Learning Curve** | Low | Medium | High | Low-Medium |
@@ -520,9 +520,9 @@ for kind, count in summary.counts_by_kind.items():
 - When you need simple drift detection out of the box
 
 **When to use alternatives:**
-- **Pandera**: Production ML pipelines with complex validation rules and custom checks
-- **Great Expectations**: Enterprise data quality monitoring with extensive reporting and data docs
-- **Pydantic**: API request/response validation or configuration management with type safety
+- **[Pandera](https://pandera.readthedocs.io/)**: Production ML pipelines with complex validation rules and custom checks
+- **[Great Expectations](https://greatexpectations.io/)**: Enterprise data quality monitoring with extensive reporting and data docs
+- **[Pydantic](https://docs.pydantic.dev/)**: API request/response validation or configuration management with type safety
 
 ---
 
@@ -682,4 +682,3 @@ View the live documentation at: https://ubc-mds.github.io/DSCI_524_G26_Data_Vali
 - [Full Documentation](https://ubc-mds.github.io/DSCI_524_G26_Data_Validation/)
 - [Issue Tracker](https://github.com/UBC-MDS/DSCI_524_G26_Data_Validation/issues)
 - [Project Board](https://github.com/UBC-MDS/DSCI_524_G26_Data_Validation/projects?query=is%3Aopen)
-

--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ conda activate pyos_data_validation
 Install the package in editable mode with development dependencies:
 
 ```bash
-pip install -e ".[dev,tests]"
+pip install -e ".[dev,tests,docs]"
 ```
 
 ### Running tests

--- a/README.md
+++ b/README.md
@@ -530,7 +530,9 @@ for kind, count in summary.counts_by_kind.items():
 
 You can install this package locally into your preferred Python environment using pip:
 
-    $ pip install -e .
+```bash
+    pip install -e .
+```
 
 ### Basic usage
 
@@ -574,13 +576,23 @@ Clone the repository:
 
 ```bash
 git clone https://github.com/UBC-MDS/DSCI_524_G26_Data_Validation.git
+```
+
+Change the directory to the project:
+
+```bash
 cd DSCI_524_G26_Data_Validation
 ```
 
-Create and activate the conda environment:
+Create the conda environment:
 
 ```bash
 conda env create -f environment.yml
+```
+
+Activate the environment: 
+
+```bash
 conda activate pyos_data_validation
 ```
 

--- a/src/pyos_data_validation/compare_contracts.py
+++ b/src/pyos_data_validation/compare_contracts.py
@@ -52,11 +52,20 @@ def compare_contracts(contract_a, contract_b):
 
     Notes
     -----
-    - This function compares contract metadata only; it does not inspect raw data.
-    - Drift is evaluated only for columns that exist in both contracts, except for
-      added/removed columns which are detected via column name differences.
-    - None handling for optional fields (min_value/max_value/allowed_values) is
-      implementation-defined; document your chosen rule if it matters for users.
+    This function compares contract metadata only and does not inspect raw data.
+    Drift is evaluated only for columns that exist in both contracts, except for
+    added or removed columns detected via column name differences. Handling of
+    optional fields (min_value, max_value, allowed_values) is implementation-
+    defined; document your chosen rule if it matters for users.
+
+    Raises
+    ------
+    TypeError
+        If contract_a or contract_b is not a Contract instance, or if a column
+        rule is not a ColumnRule instance.
+    ValueError
+        If max_missing_frac is non-numeric, outside [0, 1], or if min_value
+        exceeds max_value.
 
     Examples
     --------

--- a/src/pyos_data_validation/infer_contract.py
+++ b/src/pyos_data_validation/infer_contract.py
@@ -27,6 +27,11 @@ def infer_contract(df):
         A Contract object mapping column names to ColumnRule definitions,
         describing the expected schema and constraints of the dataset.
 
+    Raises
+    ------
+    TypeError
+        If df is not a pandas DataFrame.
+
     Examples
     --------
     >>> import pandas as pd

--- a/src/pyos_data_validation/summarize_violations.py
+++ b/src/pyos_data_validation/summarize_violations.py
@@ -98,17 +98,17 @@ def summarize_violations(
 
     >>> import pandas as pd
     >>> from pyos_data_validation import infer_contract, validate_contract, summarize_violations
-    >>> 
+    >>>
     >>> # Create training data to establish contract
     >>> training_df = pd.DataFrame({
     ...     "age": [25, 40, 35],
     ...     "salary": [50000, 75000, 62000],
     ...     "department": ["HR", "Engineering", "Sales"]
     ... })
-    >>> 
+    >>>
     >>> # Infer contract from training data
     >>> contract = infer_contract(training_df)
-    >>> 
+    >>>
     >>> # Create test data with violations
     >>> test_df = pd.DataFrame({
     ...     "age": [30, 55, 22],  # 55 and 22 outside expected range
@@ -116,16 +116,16 @@ def summarize_violations(
     ...     "department": ["HR", "Sales", "Marketing"],  # Marketing not in contract
     ...     "bonus": [5000, 8000, 3000]  # Extra column not in contract
     ... })
-    >>> 
+    >>>
     >>> # Validate and get issues
     >>> result = validate_contract(test_df, contract)
     >>> summary = summarize_violations(result, top_k=3)
-    >>> 
+    >>>
     >>> print(f"Validation passed: {summary.ok}")
     Validation passed: False
     >>> print(f"Found {len(summary.top_issues)} critical issues")
     Found 3 critical issues
-    >>> 
+    >>>
     >>> # Show top issues by severity
     >>> for issue in summary.top_issues:
     ...     print(f"  - {issue.column}: {issue.kind}")
@@ -137,7 +137,7 @@ def summarize_violations(
 
     >>> print(summary.counts_by_kind)
     {'extra_column': 1, 'range': 3, 'category': 1}
-    >>> 
+    >>>
     >>> # Check for critical schema issues
     >>> if summary.counts_by_kind.get('missing_column', 0) > 0:
     ...     print("Critical: Missing required columns!")
@@ -160,7 +160,7 @@ def summarize_violations(
     ...         'missingness': 3
     ...     }
     ... )
-    >>> 
+    >>>
     >>> # Now range issues come first
     >>> print(f"Top issue type: {custom_summary.top_issues[0].kind}")
     Top issue type: range
@@ -175,10 +175,10 @@ def summarize_violations(
     ...     "salary": [58000, 72000],
     ...     "department": ["HR", "Sales"]
     ... })
-    >>> 
+    >>>
     >>> result = validate_contract(valid_df, contract)
     >>> summary = summarize_violations(result)
-    >>> 
+    >>>
     >>> print(f"Validation passed: {summary.ok}")
     Validation passed: True
     >>> print(f"Issues found: {len(summary.top_issues)}")

--- a/src/pyos_data_validation/validate_contract.py
+++ b/src/pyos_data_validation/validate_contract.py
@@ -42,13 +42,13 @@ def validate_contract(df, contract, strict=True):
 
     Notes
     -----
-    The function performs the following checks:
-    - Missing columns defined in the contract
-    - Unexpected extra columns (when strict mode is enabled)
-    - Data type mismatches based on dtype string comparison
-    - Missingness violations based on maximum allowed missing fraction
-    - Minimum and maximum value violations for numeric columns
-    - Invalid or unseen categorical values
+    The function checks for missing required columns, unexpected extra columns
+    (when strict mode is enabled), data type mismatches, missingness violations,
+    numeric range violations, and invalid or unseen categorical values.
+
+    Raises
+    ------
+    None
 
     Examples
     --------

--- a/tests/unit/test_infer_contract.py
+++ b/tests/unit/test_infer_contract.py
@@ -36,6 +36,7 @@ def test_infer_contract_creates_rule_per_column():
 
     assert set(contract.columns.keys()) == {"age", "height"}
 
+
 # This test verifies that each entry in contract.columns
 # is stored as a ColumnRule object.
 # This ensures the contract contains structured, typed rules
@@ -76,7 +77,7 @@ def test_numeric_and_categorical_rules():
     assert contract.columns["cat"].allowed_values == {"a", "b"}
 
 
-# Milestone 4 Functions 
+# Milestone 4 Functions
 # This test verifies that an empty DataFrame produces
 # an empty contract with no column rules.
 # The function should fail gracefully rather than error.
@@ -112,8 +113,3 @@ def test_boolean_column_allowed_values():
     df = pd.DataFrame({"flag": [True, False, True]})
     contract = infer_contract(df)
     assert contract.columns["flag"].allowed_values == {"True", "False"}
-
-
-
-
-

--- a/tests/unit/test_summarize_violations.py
+++ b/tests/unit/test_summarize_violations.py
@@ -21,12 +21,12 @@ from pyos_data_validation.types import ValidationResult, Issue
 
 def test_empty_result():
     """Test that empty ValidationResult returns empty Summary.
-    
+
     When validation passes with no issues, summarize_violations should:
     - Return ok=True (matching the input result)
     - Return an empty top_issues list
     - Return an empty counts_by_kind dictionary
-    
+
     This is the "happy path" scenario where all data is valid.
     """
     result = ValidationResult(ok=True, issues=[])
@@ -40,12 +40,12 @@ def test_empty_result():
 
 def test_single_issue():
     """Test with one issue.
-    
+
     With exactly one validation issue, summarize_violations should:
     - Return ok=False
     - Return that single issue in top_issues
     - Count that issue correctly in counts_by_kind
-    
+
     This tests the minimal failing case.
     """
     issue = Issue(kind="dtype", message="Type mismatch", column="age")
@@ -61,11 +61,11 @@ def test_single_issue():
 
 def test_ok_field_matches_result():
     """Test that summary.ok matches result.ok.
-    
+
     The summary's ok field should always mirror the validation result's ok field:
     - True when result.ok is True
     - False when result.ok is False
-    
+
     This ensures consistency between validation results and summaries.
     """
     result_ok = ValidationResult(ok=True, issues=[])
@@ -86,11 +86,11 @@ def test_ok_field_matches_result():
 
 def test_top_k_limits_results():
     """Test that top_k limits the number of returned issues.
-    
+
     The top_k parameter should:
     - Limit top_issues to the specified number
     - NOT affect counts_by_kind (which should include all issues)
-    
+
     This is important for producing concise summaries while maintaining
     complete statistics about all issue types.
     """
@@ -108,11 +108,11 @@ def test_top_k_limits_results():
 
 def test_top_k_exceeds_issue_count():
     """Test that top_k larger than issue count returns all issues.
-    
+
     When top_k is larger than the number of available issues:
     - Return all available issues
     - Do not pad with empty/null issues
-    
+
     This prevents array index errors and handles small issue lists gracefully.
     """
     issues = [
@@ -139,12 +139,12 @@ def test_top_k_exceeds_issue_count():
 )
 def test_top_k_various_values(top_k, expected_count):
     """Test top_k with various values using parametrization.
-    
+
     This parametrized test verifies that top_k works correctly across
     a range of values, including edge cases like:
     - top_k = 1 (minimum)
     - top_k > number of issues (returns all)
-    
+
     Ensures robust handling of different top_k parameters.
     """
     issues = [
@@ -164,7 +164,7 @@ def test_top_k_various_values(top_k, expected_count):
 
 def test_severity_ranking():
     """Test that issues are ranked by severity using default weights.
-    
+
     Default severity weights (higher = more severe):
     - missing_column: 10 (most severe)
     - extra_column: 8
@@ -172,7 +172,7 @@ def test_severity_ranking():
     - range: 5
     - category: 5
     - missingness: 3 (least severe)
-    
+
     This test ensures schema-level issues (missing columns) are prioritized
     over distribution-level issues (missingness).
     """
@@ -193,11 +193,11 @@ def test_severity_ranking():
 
 def test_custom_weights():
     """Test that custom weights override defaults.
-    
+
     Users can provide custom weights to prioritize specific issue types
     based on their use case. For example, a user might care more about
     range violations than dtype mismatches.
-    
+
     Custom weights completely replace the defaults.
     """
     issues = [
@@ -215,11 +215,11 @@ def test_custom_weights():
 
 def test_unknown_kind_defaults_to_weight_one():
     """Test that issue kinds not in custom weights default to weight 1.
-    
+
     When custom weights are provided but don't cover all issue kinds:
     - Known kinds use their specified weights
     - Unknown kinds default to weight 1
-    
+
     This ensures all issues are still ranked, even with partial weight
     specifications.
     """
@@ -239,10 +239,10 @@ def test_unknown_kind_defaults_to_weight_one():
 
 def test_float_weights():
     """Test that float weights work correctly.
-    
+
     Weights can be float values (not just integers), allowing for
     fine-grained severity tuning.
-    
+
     This is useful when users need precise control over prioritization.
     """
     issues = [
@@ -263,12 +263,12 @@ def test_float_weights():
 
 def test_tiebreaker_ordering():
     """Test that issues with same weight are ordered by column, then kind.
-    
+
     When multiple issues have the same severity weight, they are ordered by:
     1. Column name (None/null sorts first, then alphabetically)
     2. Kind (alphabetically)
     3. Original order in result.issues
-    
+
     This deterministic tiebreaking ensures consistent, predictable results
     even when issues have equal severity.
     """
@@ -306,12 +306,12 @@ def test_tiebreaker_ordering():
 
 def test_counts_by_kind_with_multiple_kinds():
     """Test that counts_by_kind correctly groups diverse issues.
-    
+
     The counts_by_kind dictionary should:
     - Group issues by their kind
     - Count each group accurately
     - Include all kinds present in the result
-    
+
     This provides a high-level overview of issue distribution,
     useful for identifying patterns in validation failures.
     """
@@ -338,10 +338,10 @@ def test_counts_by_kind_with_multiple_kinds():
 
 def test_counts_by_kind_single_kind():
     """Test counts_by_kind with all issues of same kind.
-    
+
     When all issues are of the same type, counts_by_kind should
     have a single entry with the correct total count.
-    
+
     This edge case ensures the counting logic handles homogeneous
     issue lists correctly.
     """
@@ -362,10 +362,10 @@ def test_counts_by_kind_single_kind():
 
 def test_invalid_result_type():
     """Test that invalid result type raises TypeError.
-    
+
     summarize_violations should only accept ValidationResult objects.
     Passing any other type should raise a clear TypeError.
-    
+
     This prevents misuse and provides clear error messages.
     """
     with pytest.raises(TypeError):
@@ -374,7 +374,7 @@ def test_invalid_result_type():
 
 def test_negative_top_k():
     """Test that negative top_k raises ValueError.
-    
+
     top_k must be a positive integer. Negative values don't make
     logical sense (can't return negative number of issues).
     """
@@ -386,7 +386,7 @@ def test_negative_top_k():
 
 def test_zero_top_k():
     """Test that top_k=0 raises ValueError.
-    
+
     top_k must be at least 1. Zero doesn't make sense as it would
     return no issues, defeating the purpose of summarization.
     """
@@ -398,10 +398,10 @@ def test_zero_top_k():
 
 def test_non_integer_top_k():
     """Test that non-integer top_k raises TypeError or ValueError.
-    
+
     top_k must be an integer. Float or string values should be rejected
     even if they could be converted to integers.
-    
+
     This enforces type safety and prevents ambiguous behavior.
     """
     result = ValidationResult(ok=True, issues=[])
@@ -415,7 +415,7 @@ def test_non_integer_top_k():
 
 def test_negative_weight_raises_error():
     """Test that negative weights raise ValueError.
-    
+
     Weights represent severity and must be positive. Negative weights
     would create illogical prioritization.
     """
@@ -427,7 +427,7 @@ def test_negative_weight_raises_error():
 
 def test_zero_weight_raises_error():
     """Test that zero weights raise ValueError.
-    
+
     Zero-weighted issues would have no priority and create ambiguous
     sorting. Minimum weight should be a small positive number.
     """
@@ -439,7 +439,7 @@ def test_zero_weight_raises_error():
 
 def test_non_numeric_weight_raises_error():
     """Test that non-numeric weight values raise ValueError.
-    
+
     Weights must be numeric (int or float) to enable severity comparison.
     String values like "high" or "critical" are not allowed.
     """
@@ -451,10 +451,10 @@ def test_non_numeric_weight_raises_error():
 
 def test_weights_not_dict_raises_error():
     """Test that non-dict weights parameter raises TypeError.
-    
+
     The weights parameter must be a dictionary mapping issue kinds to
     numeric weights. Lists, tuples, or strings are not valid.
-    
+
     This enforces the expected data structure.
     """
     result = ValidationResult(ok=True, issues=[])
@@ -468,10 +468,10 @@ def test_weights_not_dict_raises_error():
 
 def test_mixed_valid_invalid_weights():
     """Test that dict with some invalid weights raises ValueError.
-    
+
     If even one weight in the dictionary is invalid (negative, zero,
     or non-numeric), the entire weights parameter should be rejected.
-    
+
     This fails-fast approach prevents partial application of invalid
     weight specifications.
     """
@@ -492,12 +492,12 @@ def test_mixed_valid_invalid_weights():
 
 def test_realistic_validation_summary():
     """Test with a realistic scenario combining multiple aspects.
-    
+
     This integration test simulates a real-world validation failure with:
     - Multiple issue types at different severity levels
     - A mix of schema and distribution problems
     - More issues than top_k (tests truncation)
-    
+
     Validates that the complete workflow produces sensible, actionable
     summaries that help users prioritize fixes.
     """
@@ -539,7 +539,7 @@ def test_realistic_validation_summary():
 
 def test_all_default_weight_kinds():
     """Test that all default weight kinds are handled correctly.
-    
+
     This comprehensive test includes one issue of each default kind:
     - missing_column (weight 10)
     - extra_column (weight 8)
@@ -547,7 +547,7 @@ def test_all_default_weight_kinds():
     - range (weight 5)
     - category (weight 5)
     - missingness (weight 3)
-    
+
     Verifies the complete default severity hierarchy is working as designed.
     """
     issues = [
@@ -591,10 +591,10 @@ def test_all_default_weight_kinds():
 
 def test_top_k_equals_one():
     """Test top_k=1 returns only the most severe issue.
-    
+
     With top_k=1, the summary should contain only the single highest-priority
     issue, but counts_by_kind should still reflect all issues.
-    
+
     This is useful for "show me the #1 problem to fix first" scenarios.
     """
     issues = [
@@ -614,10 +614,10 @@ def test_top_k_equals_one():
 
 def test_large_number_of_issues():
     """Test with a large number of issues.
-    
+
     Ensures the function handles large validation results efficiently without
     performance degradation or memory issues.
-    
+
     With 1000 issues but top_k=5, only the top 5 should be returned,
     but all 1000 should be counted.
     """
@@ -634,13 +634,13 @@ def test_large_number_of_issues():
 
 def test_none_column_sorting():
     """Test that issues with column=None are handled correctly in sorting.
-    
+
     Dataset-level issues (column=None) represent problems not tied to a
     specific column. These should sort before column-specific issues.
-    
+
     After dataset-level issues, column-specific issues sort alphabetically
     by column name.
-    
+
     This ensures dataset-level problems get visibility.
     """
     issues = [

--- a/tests/unit/test_validate_contract.py
+++ b/tests/unit/test_validate_contract.py
@@ -97,62 +97,62 @@ from pyos_data_validation.types import Contract, ColumnRule
 def test_validate_contract():
     """
     Comprehensive test covering 5 core validation scenarios.
-    
+
     This test function validates the primary edge cases that validate_contract
     must handle correctly. Each scenario tests a different validation rule.
-    
+
     Test Scenarios
     --------------
     1. **Success Path (Happy Path)**
        - Valid data that perfectly matches contract
        - Tests: Complete validation flow with no issues
        - Expected: result.ok = True, no issues
-    
+
     2. **Missing Required Column**
        - DataFrame missing a contract-required column
        - Tests: Schema validation in strict mode
        - Expected: result.ok = False, 'missing_column' issue
-    
+
     3. **Data Type Mismatch**
        - Column has wrong data type (string instead of int)
        - Tests: Type validation logic
        - Expected: result.ok = False, 'dtype' issue
-    
+
     4. **Numeric Range Violation**
        - Numeric value exceeds maximum bound
        - Tests: Numeric range checking
        - Expected: result.ok = False, 'range' issue
-    
+
     5. **Invalid Categorical Values**
        - Categorical value not in allowed set
        - Tests: Categorical domain validation
        - Expected: result.ok = False, 'category' issue
-    
+
     Test Data Characteristics
     -------------------------
     - Uses minimal 1-2 row DataFrames for clarity
     - Each test DataFrame isolates a single validation issue
     - Column names match standard test contract (age, city)
-    
+
     Validation Contract
     -------------------
     age:
         - Type: int64
         - Range: [0, 100]
         - Missing: Not allowed (0%)
-    
+
     city:
         - Type: object
         - Allowed: {"Vancouver", "Toronto"}
         - Missing: Allowed
-    
+
     Expected Outcomes
     -----------------
     All assertions should pass, verifying that:
     - Valid data returns ok=True
     - Each violation type is correctly detected
     - Issue kinds match expected validation failures
-    
+
     Implementation Notes
     --------------------
     This test uses a single function to cover multiple scenarios. Consider
@@ -161,20 +161,20 @@ def test_validate_contract():
     - Easier debugging (can run individual scenarios)
     - Clearer test names (self-documenting)
     - More detailed docstrings per scenario
-    
+
     See Also
     --------
     validate_contract : The function being tested
     create_test_contract : Helper to create standard test contract
-    
+
     Examples
     --------
     Run this specific test:
         $ pytest tests/test_validate_contract.py::test_validate_contract -v
-    
+
     Run with detailed output:
         $ pytest tests/test_validate_contract.py::test_validate_contract -vv
-    
+
     Drop into debugger on failure:
         $ pytest tests/test_validate_contract.py::test_validate_contract --pdb
     """


### PR DESCRIPTION
- [x] fix #55
- [x] description of feature/fix
- [ ] tests added/passed
- [x] add an entry to the [changelog](../CHANGELOG.md)

This PR resolves all documentation, tooling, and style issues raised in #55.

Specifically, it improves the accessibility of the README by removing shell prompt (`$`) prefixes from all bash commands and placing each command in its own fenced code block to make copy-paste and step-by-step execution easier. It also fixes the `quartodoc` build failure by explicitly including documentation dependencies in the recommended `pip install -e ."[dev,test]"` setup, ensuring `quartodoc` is available during documentation builds. Python compatibility has been aligned with this setup (pinned to 3.13).

In addition, docstrings have been standardized across the codebase for consistency, with all public functions now including a `Raises` section where applicable and a unified structure for the `Notes` section. The README has been enhanced with direct hyperlinks to referenced data-quality and schema-validation tools in the comparison/function reference section.

Finally, all files have been formatted and verified to comply with style guidelines. `ruff` checks pass cleanly, and CI confirms successful formatting and style validation.

