### PR TITLE
CI: Add Codecov coverage upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,4 +31,9 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest --cov --cov-report=term --cov-branch
+          pytest --cov --cov-report=term --cov-report=xml --cov-branch
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This PR adds Codecov integration by:
- Generating coverage.xml via pytest-cov in CI
- Uploading coverage reports to Codecov using the official action

No test logic or package code was modified.